### PR TITLE
tbfixprofile: update symlink 13.0 -> 17.0

### DIFF
--- a/tbfixprofile
+++ b/tbfixprofile
@@ -10,5 +10,5 @@ portdir=$(portageq get_repo_path / gentoo)
 target="$AVAILDIR"/"$1"
 
 rm -f "$target"/etc/portage/make.profile
-ln -s "$portdir"/profiles/default/linux/amd64/13.0/no-multilib "$target"/etc/portage/make.profile
+ln -s "$portdir"/profiles/default/linux/amd64/17.0/no-multilib "$target"/etc/portage/make.profile
 


### PR DESCRIPTION
tbfixprofile corrects the symlinks for make.profile, however, it is currently hardcoded to 13.0. This PR changes that to 17.0.